### PR TITLE
fix: added missing type to dto

### DIFF
--- a/apps/api/src/profiles/dto/create-profile.dto.ts
+++ b/apps/api/src/profiles/dto/create-profile.dto.ts
@@ -53,4 +53,8 @@ export class CreateProfileDto {
 
   @IsString()
   street: string;
+
+  @ValidateIf((el) => el.desc === 'Student')
+  @IsBoolean()
+  campusCommunityActive: boolean;
 }


### PR DESCRIPTION


### What does it do?

added campusCOmmunity type to dto as boolean


